### PR TITLE
WIP Ops/artefacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM public.ecr.aws/artefacts/ros2:humble-fortress-0.4.12
+
+ARG JOB_ID
+COPY . /ws/src
+WORKDIR /ws
+
+RUN apt update -y && rosdep install --from-paths src --ignore-src -r -y
+RUN source /opt/ros/humble/setup.bash --extend && MAKEFLAGS="-j1 -l1" colcon build --symlink-install --executor sequential
+
+WORKDIR /ws/src
+
+CMD source /ws/install/setup.bash && artefacts run $ARTEFACTS_JOB_NAME

--- a/artefacts.test.yaml
+++ b/artefacts.test.yaml
@@ -3,10 +3,15 @@ project: text2sim
 
 jobs:
   test:
+    package:
+      docker:
+        build:
+          dockerfile: ./Dockerfile
     runtime:
       simulator: gazebo:fortress
+      framework: null
     scenarios:
       settings:
         - name: warehouse
-          run: python generate.sdf && gz sim outputs/world_file.sdf
+          run: gz sim outputs/world_file.sdf
     type: test


### PR DESCRIPTION
work in progress toward integrating with artefacts.

Current issue is that I need to generate the sim file before execution.
the env generation script requires the OPENAI_API_KEY env variable, so this will not work

do we have any mechanism to pass an env variable to the container?

